### PR TITLE
Update CSS to enable vertical scrolling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-barcode-scanner ChangeLog
 
+## 1.3.1 - 2025-03-xx
+
+### Changed
+- Update CSS to enable vertical scrolling.
+
 ## 1.3.0 - 2025-03-10
 
 ### Changed

--- a/components/BarcodeScanner.vue
+++ b/components/BarcodeScanner.vue
@@ -268,6 +268,6 @@ function _mapFormats(formats) {
 <style>
 body {
   /* Prevents pinch to zoom on iOS & Android */
-  touch-action: none;
+  touch-action: pan-y;
 }
 </style>


### PR DESCRIPTION
#### _Resolves - bug fix_

---

### What kind of change does this PR introduce?

- Bug fix

<br/>

### What is the current behavior?

- The disabling of pinch-to-zoom also disabled vertical scrolling

<br/>

### What is the new behavior?

- Vertical scrolling is enabled, while pinch-to-zoom is still not enabled

<br/>

### Does this PR introduce a breaking change?

- No

<br/>

### How has this been tested?

- Locally on Android & iOS

<br/>

### Screenshots:

- n/a