### PR TITLE
Accommodate safe area for mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # bedrock-vue-barcode-scanner ChangeLog
 
+## 1.6.0 - 2025-06-dd
+
+### Added
+- Include prop to observe safe area for mobile devices.
+
+## Changed
+- Update screen aspect ratio for web and mobile.
+
 ## 1.5.0 - 2025-04-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.6.0 - 2025-06-dd
 
 ### Added
-- Include prop to observe safe area for mobile devices.
+- Include safe area CSS property for mobile devices.
 
 ## Changed
 - Update screen aspect ratio for web and mobile.

--- a/components/BarcodeScanner.vue
+++ b/components/BarcodeScanner.vue
@@ -222,11 +222,9 @@ export default {
       return {
         videoConstraints: {
           facingMode: 'environment',
-          aspectRatio: $q.platform.is.capacitor ?
-            width < 600 ?
-              portraitAspectRatio :
-              landscapeAspectRatio :
-            landscapeAspectRatio,
+          aspectRatio: width < height ?
+            portraitAspectRatio :
+            landscapeAspectRatio
         },
         ...(props.showQrBox && {qrbox: qrboxFunction})
       };
@@ -242,7 +240,7 @@ export default {
      * @returns {object} QR box width and height.
      */
     function qrboxFunction(viewfinderWidth, viewfinderHeight) {
-      const minEdgePercentage = 0.85; // 85%
+      const minEdgePercentage = 0.75; // 75%
       const minEdgeSize = Math.min(viewfinderWidth, viewfinderHeight);
       const qrboxSize = Math.floor(minEdgeSize * minEdgePercentage);
       return {

--- a/components/BarcodeScanner.vue
+++ b/components/BarcodeScanner.vue
@@ -4,7 +4,6 @@
       :tip-text="tipText"
       :camera-list="cameraList"
       :camera-error="cameraError"
-      :safe-area-mode="safeAreaMode"
       :loading-camera="loadingCamera"
       :camera-constraints="cameraConstraints"
       @zoom-update="onZoomChange"
@@ -42,10 +41,6 @@ export default {
       default: false
     },
     torchOn: {
-      type: Boolean,
-      default: false
-    },
-    safeAreaMode: {
       type: Boolean,
       default: false
     }

--- a/components/BarcodeScanner.vue
+++ b/components/BarcodeScanner.vue
@@ -4,6 +4,7 @@
       :tip-text="tipText"
       :camera-list="cameraList"
       :camera-error="cameraError"
+      :safe-area-mode="safeAreaMode"
       :loading-camera="loadingCamera"
       :camera-constraints="cameraConstraints"
       @zoom-update="onZoomChange"
@@ -41,6 +42,10 @@ export default {
       default: false
     },
     torchOn: {
+      type: Boolean,
+      default: false
+    },
+    safeAreaMode: {
       type: Boolean,
       default: false
     }
@@ -224,7 +229,7 @@ export default {
      *
      * @param {number} viewfinderWidth - Video screen width.
      * @param {number} viewfinderHeight - Video screen height.
-     * @returns {object} Qrbox width and height.
+     * @returns {object} QR box width and height.
      */
     function qrboxFunction(viewfinderWidth, viewfinderHeight) {
       const minEdgePercentage = 0.9; // 90%

--- a/components/BarcodeScanner.vue
+++ b/components/BarcodeScanner.vue
@@ -215,9 +215,19 @@ export default {
     }
 
     function getCameraScanConfig() {
-      const aspectRatio = parseFloat((innerHeight / innerWidth).toFixed(3));
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+      const landscapeAspectRatio = width / height;
+      const portraitAspectRatio = height / width;
       return {
-        aspectRatio,
+        videoConstraints: {
+          facingMode: 'environment',
+          aspectRatio: $q.platform.is.capacitor ?
+            width < 600 ?
+              portraitAspectRatio :
+              landscapeAspectRatio :
+            landscapeAspectRatio,
+        },
         ...(props.showQrBox && {qrbox: qrboxFunction})
       };
     }
@@ -232,7 +242,7 @@ export default {
      * @returns {object} QR box width and height.
      */
     function qrboxFunction(viewfinderWidth, viewfinderHeight) {
-      const minEdgePercentage = 0.9; // 90%
+      const minEdgePercentage = 0.85; // 85%
       const minEdgeSize = Math.min(viewfinderWidth, viewfinderHeight);
       const qrboxSize = Math.floor(minEdgeSize * minEdgePercentage);
       return {

--- a/components/ScannerUI.vue
+++ b/components/ScannerUI.vue
@@ -42,16 +42,13 @@
       fab
       :ripple="false"
       size="16px"
-      :color="cameraError ? 'primary' : 'white'"
       icon="fas fa-times"
-      class="q-ma-sm absolute-top-right"
-      :style="safeAreaMode ? 'margin-top: 35px' : 'margin-top: 8px'"
+      :color="cameraError ? 'primary' : 'white'"
+      class="q-ma-sm absolute-top-right close-button"
       @click="handleClose" />
 
     <!-- Zoom slider -->
-    <q-item
-      class="absolute-bottom q-mx-xl"
-      :style="safeAreaMode ? 'bottom: 125px' : 'bottom: 110px'">
+    <q-item class="absolute-bottom q-mx-xl zoom-slider">
       <q-item-section side>
         <q-icon
           color="white"
@@ -78,15 +75,12 @@
       v-if="tipText"
       ref="tipText"
       class="absolute-bottom tip-text text-white
-      text-center full-width q-py-sm"
-      :style="safeAreaMode ? 'margin-bottom: 90px': 'margin-bottom: 70px'">
+      text-center full-width q-py-sm">
       {{tipText}}
     </div>
 
     <!-- Bottom buttons -->
-    <div
-      class="full-width absolute-bottom bottom-container"
-      :style="safeAreaMode ? 'height: 90px' : 'height: 70px'">
+    <div class="full-width absolute-bottom bottom-container">
       <q-btn-group
         spread
         class="button-group full-width shadow-0">
@@ -143,10 +137,6 @@ import {useQuasar} from 'quasar';
 export default {
   name: 'ScannerUI',
   props: {
-    safeAreaMode: {
-      type: Boolean,
-      default: false
-    },
     tipText: {
       type: String,
       default: '',
@@ -210,8 +200,9 @@ export default {
 
 <style>
 .tip-text {
-  margin-bottom: 90px;
   background-color: rgba(0, 0, 0, 0.7);
+  /* observe safe area if value is present on mobile device */
+  margin-bottom: calc(env(safe-area-inset-bottom, 0px) + 70px);
 }
 .bottom-container {
   height: 90px;
@@ -219,8 +210,15 @@ export default {
   border-radius: 0;
   justify-content: flex-start;
   background-color: rgba(31, 41, 55, 0.9);
+  height: calc(env(safe-area-inset-bottom, 0px) + 70px);
 }
 .button-group {
   height: 70px;
+}
+.close-button {
+  margin-top: calc(env(safe-area-inset-top, 0px) + 8px);
+}
+.zoom-slider {
+  margin-bottom: calc(env(safe-area-inset-bottom, 0px) + 110px);
 }
 </style>

--- a/components/ScannerUI.vue
+++ b/components/ScannerUI.vue
@@ -51,7 +51,7 @@
     <!-- Zoom slider -->
     <q-item
       class="absolute-bottom q-mx-xl"
-      style="bottom: 125px">
+      :style="safeAreaMode ? 'bottom: 125px' : 'bottom: 110px'">
       <q-item-section side>
         <q-icon
           color="white"

--- a/components/ScannerUI.vue
+++ b/components/ScannerUI.vue
@@ -36,15 +36,6 @@
       </div>
     </div>
 
-    <!-- Tip Text -->
-    <div
-      v-if="tipText"
-      ref="tipText"
-      class="absolute-bottom tip-text text-white
-      text-center full-width q-py-sm">
-      {{tipText}}
-    </div>
-
     <!-- Close -->
     <q-btn
       flat
@@ -54,12 +45,13 @@
       :color="cameraError ? 'primary' : 'white'"
       icon="fas fa-times"
       class="q-ma-sm absolute-top-right"
+      :style="safeAreaMode ? 'margin-top: 35px' : 'margin-top: 8px'"
       @click="handleClose" />
 
     <!-- Zoom slider -->
     <q-item
       class="absolute-bottom q-mx-xl"
-      style="bottom: 100px">
+      style="bottom: 125px">
       <q-item-section side>
         <q-icon
           color="white"
@@ -81,49 +73,63 @@
       </q-item-section>
     </q-item>
 
-    <!-- Bottom buttons -->
-    <q-btn-group
-      class="absolute-bottom full-width bottom-buttons"
-      spread>
-      <!-- Camera Button -->
-      <q-btn-dropdown
-        flat
-        no-caps
-        text-color="white"
-        icon="fas fa-video"
-        label="Camera Select"
-        style="font-weight: 600"
-        :disabled="loadingCamera">
-        <q-list>
-          <q-item
-            v-for="camera in cameraList"
-            :key="camera.deviceId"
-            v-close-popup
-            clickable
-            @click="onChangeCamera(camera)">
-            <q-item-section>
-              <q-item-label>{{camera.label}}</q-item-label>
-            </q-item-section>
-          </q-item>
-        </q-list>
-      </q-btn-dropdown>
-      <q-separator
-        inset
-        vertical
-        color="grey-8" />
+    <!-- Tip Text -->
+    <div
+      v-if="tipText"
+      ref="tipText"
+      class="absolute-bottom tip-text text-white
+      text-center full-width q-py-sm"
+      :style="safeAreaMode ? 'margin-bottom: 90px': 'margin-bottom: 70px'">
+      {{tipText}}
+    </div>
 
-      <!-- Torch -->
-      <q-btn
-        flat
-        no-caps
-        color="white"
-        text-color="white"
-        icon="fas fa-bolt"
-        label="Light On/ Off"
-        style="font-weight: 600"
-        :disabled="loadingCamera"
-        @click="handleToggleTorch" />
-    </q-btn-group>
+    <!-- Bottom buttons -->
+    <div
+      class="full-width absolute-bottom bottom-container"
+      :style="safeAreaMode ? 'height: 90px' : 'height: 70px'">
+      <q-btn-group
+        spread
+        class="button-group full-width shadow-0">
+        <!-- Camera Button -->
+        <q-btn-dropdown
+          flat
+          no-caps
+          text-color="white"
+          icon="fas fa-video"
+          label="Camera Select"
+          style="font-weight: 600"
+          :disabled="loadingCamera">
+          <q-list>
+            <q-item
+              v-for="camera in cameraList"
+              :key="camera.deviceId"
+              v-close-popup
+              clickable
+              @click="onChangeCamera(camera)">
+              <q-item-section>
+                <q-item-label>{{camera.label}}</q-item-label>
+              </q-item-section>
+            </q-item>
+          </q-list>
+        </q-btn-dropdown>
+        <q-separator
+          inset
+          vertical
+          color="grey-8" />
+
+        <!-- Torch -->
+        <q-btn
+          flat
+          no-caps
+          color="white"
+          text-color="white"
+          icon="fas fa-bolt"
+          label="Light On/ Off"
+          style="font-weight: 600"
+          :disabled="loadingCamera"
+          @click="handleToggleTorch" />
+      </q-btn-group>
+    </div>
   </div>
 </template>
 
@@ -137,6 +143,10 @@ import {useQuasar} from 'quasar';
 export default {
   name: 'ScannerUI',
   props: {
+    safeAreaMode: {
+      type: Boolean,
+      default: false
+    },
     tipText: {
       type: String,
       default: '',
@@ -200,12 +210,17 @@ export default {
 
 <style>
 .tip-text {
-  margin-bottom: 50px;
+  margin-bottom: 90px;
   background-color: rgba(0, 0, 0, 0.7);
 }
-.bottom-buttons {
-  height: 50px;
+.bottom-container {
+  height: 90px;
+  display: flex;
   border-radius: 0;
+  justify-content: flex-start;
   background-color: rgba(31, 41, 55, 0.9);
+}
+.button-group {
+  height: 70px;
 }
 </style>


### PR DESCRIPTION
#### _Resolves - adds safe area space for mobile devices_

---

### What kind of change does this PR introduce?

- UI update

<br/>

### What is the current behavior?

- The UI buttons on the top and bottom of the screen run into the notch and other safe area obstructions when ran on a mobile device.
- The camera window does not cover the entire web page or mobile device.

<br/>

### What is the new behavior?

- A prop is available to increase the "padding" on the top and the bottom of the screen to accommodate the safe area on mobile devices.
- The live video feed now takes up the entire screen on mobile and web.

<br/>

### Does this PR introduce a breaking change?

- No

<br/>

### How has this been tested?

- On web, iOS, and Android
<br/>

### Screenshots:

- n/a